### PR TITLE
Authentication endpoint1 - commons & admin end points

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/quora-api/src/main/java/com/upgrad/quora/api/controller/AdminController.java
+++ b/quora-api/src/main/java/com/upgrad/quora/api/controller/AdminController.java
@@ -5,6 +5,7 @@ import com.upgrad.quora.service.business.AdminBusinessService;
 import com.upgrad.quora.service.exception.AuthorizationFailedException;
 import com.upgrad.quora.service.exception.UserNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -20,6 +21,9 @@ public class AdminController {
     public ResponseEntity<UserDeleteResponse> deleteUser(@RequestHeader("authorization")final String authorization,
                                                          @PathVariable("userId")final String uuid) throws AuthorizationFailedException, UserNotFoundException {
 //  Add the Controller logic to delete the user
-        return null;
+        adminBusinessService.deleteUser(authorization, uuid);
+        UserDeleteResponse deleteResponse = new UserDeleteResponse().id(uuid).status("USER SUCCESSFULLY DELETED");
+
+        return new ResponseEntity<UserDeleteResponse>(deleteResponse, HttpStatus.OK);
     }
 }

--- a/quora-api/src/main/java/com/upgrad/quora/api/controller/CommonController.java
+++ b/quora-api/src/main/java/com/upgrad/quora/api/controller/CommonController.java
@@ -21,7 +21,15 @@ public class CommonController {
     @RequestMapping(method = RequestMethod.GET, path = "/userprofile/{userId}", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
     public ResponseEntity<UserDetailsResponse> getUserDetails(@RequestHeader("authorization")final String authorization, @PathVariable("userId")final String uuid) throws AuthorizationFailedException, UserNotFoundException {
 //       Write the controller logic to fetch user details
-        return null;
+        String[] bearerToken = authorization.split("Bearer ");
 
+        UserEntity userEntity = commonBusinessService.getUser(bearerToken[1], uuid);
+
+        UserDetailsResponse userDetailsResponse = new UserDetailsResponse().firstName(userEntity.getFirstName())
+                .lastName(userEntity.getLastName()).userName(userEntity.getUserName())
+                .emailAddress(userEntity.getEmail()).contactNumber(userEntity.getContactNumber())
+                .country(userEntity.getCountry()).dob(userEntity.getDob()).aboutMe(userEntity.getAboutMe());
+
+        return new ResponseEntity<UserDetailsResponse>(userDetailsResponse, HttpStatus.OK);
     }
 }

--- a/quora-api/src/main/java/com/upgrad/quora/api/exception/RestExceptionHandler.java
+++ b/quora-api/src/main/java/com/upgrad/quora/api/exception/RestExceptionHandler.java
@@ -43,14 +43,16 @@ public class RestExceptionHandler {
     public ResponseEntity<ErrorResponse> authorizationfailed(AuthorizationFailedException exc, WebRequest request)
     {
 //      Handle the exception for authorizationfailedexception
-        return null;
+        return new ResponseEntity<ErrorResponse>(new ErrorResponse().code(exc.getCode()).message(exc.getErrorMessage()),
+                HttpStatus.UNAUTHORIZED);
     }
 
     @ExceptionHandler(UserNotFoundException.class)
     public ResponseEntity<ErrorResponse> userNotFound(UserNotFoundException exc, WebRequest request)
     {
 //      Handle the exception for usernotfoundexception
-        return null;
+        return new ResponseEntity<ErrorResponse>(new ErrorResponse().code(exc.getCode()).message(exc.getErrorMessage()),
+                HttpStatus.UNAUTHORIZED); // in proman we use NOT_FOUND (Response 404), but its not given in quora response definition
     }
 
 }

--- a/quora-service/src/main/java/com/upgrad/quora/service/business/AdminBusinessService.java
+++ b/quora-service/src/main/java/com/upgrad/quora/service/business/AdminBusinessService.java
@@ -1,6 +1,7 @@
 package com.upgrad.quora.service.business;
 
 import com.upgrad.quora.service.dao.UserDao;
+import com.upgrad.quora.service.entity.UserAuthTokenEntity;
 import com.upgrad.quora.service.entity.UserEntity;
 import com.upgrad.quora.service.exception.AuthorizationFailedException;
 import com.upgrad.quora.service.exception.UserNotFoundException;
@@ -9,14 +10,37 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.ZonedDateTime;
+
 @Service
 public class AdminBusinessService {
     @Autowired
     private UserDao userDao;
 
     @Transactional(propagation = Propagation.REQUIRED)
-    public UserEntity deleteUser(final String authorization, final String uuid) throws AuthorizationFailedException, UserNotFoundException {
+    public void deleteUser(final String authorization, final String uuid) throws AuthorizationFailedException, UserNotFoundException {
 //   Add the business logic to delete the user
-        return null;
+
+        UserAuthTokenEntity userAuthTokenEntity = userDao.getAuthToken(authorization);
+        if(userAuthTokenEntity == null) {
+            throw new AuthorizationFailedException("ATHR-001", "User has not signed in");
+        }
+
+        ZonedDateTime logoutAtTime = userAuthTokenEntity.getLogoutAt();
+        if(logoutAtTime != null) {
+            throw new AuthorizationFailedException("ATHR-002", "User is signed out");
+        }
+
+        UserEntity userEntity = userDao.getUserByUuid(uuid);
+        if(userEntity == null) {
+            throw new UserNotFoundException("USR-001","User with entered uuid to be deleted does not exist");
+        }
+
+        String role = userEntity.getRole();
+        if(role.equals("nonadmin")) {
+            throw new AuthorizationFailedException("ATHR-003", "Unauthorized Access, Entered user is not an admin");
+        }
+        userDao.deleteAuthToken(userAuthTokenEntity);
+        userDao.deleteUser(userEntity);
     }
 }

--- a/quora-service/src/main/java/com/upgrad/quora/service/business/CommonBusinessService.java
+++ b/quora-service/src/main/java/com/upgrad/quora/service/business/CommonBusinessService.java
@@ -1,6 +1,7 @@
 package com.upgrad.quora.service.business;
 
 import com.upgrad.quora.service.dao.UserDao;
+import com.upgrad.quora.service.entity.UserAuthTokenEntity;
 import com.upgrad.quora.service.entity.UserEntity;
 import com.upgrad.quora.service.exception.AuthorizationFailedException;
 import com.upgrad.quora.service.exception.UserNotFoundException;
@@ -8,6 +9,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.ZonedDateTime;
 
 @Service
 public class CommonBusinessService {
@@ -18,6 +21,24 @@ public class CommonBusinessService {
     @Transactional(propagation = Propagation.REQUIRED)
     public UserEntity getUser(final String authorization, final String uuid) throws AuthorizationFailedException, UserNotFoundException {
 //        Write he business logic to fetch user details
-        return null;
+        UserAuthTokenEntity userAuthTokenEntity = userDao.getAuthToken(authorization);
+
+        if(userAuthTokenEntity == null) {
+            throw new AuthorizationFailedException("ATHR-001", "User has not signed in");
+        }
+
+        final ZonedDateTime logoutAtTime = userAuthTokenEntity.getLogoutAt();
+
+        if(logoutAtTime != null) { // check logic
+            throw new AuthorizationFailedException("ATHR-002", "User is signed out.Sign in first to get user details");
+        }
+
+        UserEntity userEntity = userDao.getUserByUuid(uuid);
+
+        if(userEntity == null) {
+            throw new UserNotFoundException("USR-001", "User with entered uuid does not exist");
+        }
+
+        return userEntity;
     }
 }

--- a/quora-service/src/main/java/com/upgrad/quora/service/dao/UserDao.java
+++ b/quora-service/src/main/java/com/upgrad/quora/service/dao/UserDao.java
@@ -66,16 +66,22 @@ public class UserDao {
         return userAuthTokenEntity;
     }
 
-    public UserEntity deleteUser(final UserEntity userEntity)
+    public void deleteUser(final UserEntity userEntity)
     {
 //       This method deletes the user from the database
-        return null;
+        entityManager.remove(userEntity);
+
     }
 
     public UserEntity getUserByUuid(final String uuid)
     {
 //      This method fetch the user from the database based on uuid
-        return null;
+        try{
+            return entityManager.createNamedQuery("userByUuid", UserEntity.class).setParameter("uuid", uuid)
+                    .getSingleResult();
+        } catch(NoResultException nre) {
+            return null;
+        }
     }
 
 }

--- a/quora-service/src/main/java/com/upgrad/quora/service/dao/UserDao.java
+++ b/quora-service/src/main/java/com/upgrad/quora/service/dao/UserDao.java
@@ -84,4 +84,8 @@ public class UserDao {
         }
     }
 
+    public void deleteAuthToken(final UserAuthTokenEntity userAuthTokenEntity) {
+        entityManager.remove(userAuthTokenEntity);
+    }
+
 }


### PR DESCRIPTION
you can merge & refactor if required. Admin control with user entity as return will give 500 error, this is because after using remove command user entity does not exist and is null, so the userEntity.getUuid() command will give a null pointer exception as a result a 500 error. And with void return type it is working absolutely fine and same logic was used. Same logic was used in Technical Blog also.